### PR TITLE
Use iv-more-chars instead of obsolete function counsel-more-chars

### DIFF
--- a/avy-migemo-e.g.counsel.el
+++ b/avy-migemo-e.g.counsel.el
@@ -144,7 +144,7 @@ after `counsel-unquote-regex-parens'."
   "The same as `counsel-ag-function' except for using migemo."
   (when (null extra-pt-args)
     (setq extra-pt-args ""))
-  (or (counsel-more-chars)
+  (or (ivy-more-chars)
       (let ((default-directory (ivy-state-directory ivy-last))
             (regex (counsel-unquote-regex-parens-migemo ; Adapt for migemo
                     (setq ivy--old-re
@@ -236,7 +236,7 @@ after `counsel-unquote-regex-parens'."
 
 (defun counsel-grep-function-migemo (string)
   "The same as `counsel-grep-function' except for using migemo."
-  (or (counsel-more-chars)
+  (or (ivy-more-chars)
       (let ((regex (counsel-unquote-regex-parens-migemo ; Adapt for migemo
                     (setq ivy--old-re
                           (ivy--regex-migemo string))))


### PR DESCRIPTION
package.el経由でインストールしてswiperでavy-migemoを利用したところ、下記のような警告がでました。
ので、メッセージ通り、利用する関数を変更しました。

```
~/.emacs.d/elpa/avy-migemo-20180716.1455/avy-migemo-e.g.counsel.el:Warning:
    ‘counsel-more-chars’ is an obsolete function (as of 0.10.0); use
    ‘ivy-more-chars’ instead.
```