### PR TITLE
Use avy-jump instead of obsolete function avy--generic-jump

### DIFF
--- a/avy-migemo-e.g.zzz-to-char.el
+++ b/avy-migemo-e.g.zzz-to-char.el
@@ -39,16 +39,16 @@
       (let ((p (point))
             (avy-all-windows nil))
         (avy-with zzz-to-char
-          (avy--generic-jump
+          (avy-jump
            (if (= 13 char)
                "\n"
              ;; Adapt for migemo
              (avy-migemo-regex-quote-concat (string char)))
-           nil avy-style
-           (max (- p zzz-to-char-reach)
-                (window-start))
-           (min (+ p zzz-to-char-reach)
-                (window-end (selected-window) t))))
+           :window-flip nil
+           :beg (max (- p zzz-to-char-reach)
+                     (window-start))
+           :end (min (+ p zzz-to-char-reach)
+                     (window-end (selected-window) t))))
         (let ((n (point)))
           (when (/= n p)
             (cl-destructuring-bind (beg . end)


### PR DESCRIPTION
以下のようにして`avy-migemo-e.g.zzz-to-char.el`を導入しました．
```emacs-lisp
(use-package zzz-to-char
  :ensure t
  :bind ("M-z" . zzz-to-char)
  )

(use-package avy-migemo-e.g.zzz-to-char
  :ensure avy-migemo
  :after zzz-to-char
  )
```

`zzz-to-char`を実行したところ以下の警告が出ました．
```
~/.emacs.d/elpa/avy-migemo-20180716.1455/avy-migemo-e.g.zzz-to-char.el:Warning:
    avy--generic-jump called with 5 arguments, but accepts only 2-4
~/.emacs.d/elpa/avy-migemo-20180716.1455/avy-migemo-e.g.zzz-to-char.el:Warning:
    ‘avy--generic-jump’ is an obsolete function (as of 0.4.0); use
    ‘avy-jump’ instead.
~/.emacs.d/elpa/avy-migemo-20180716.1455/avy-migemo-e.g.zzz-to-char.el:Warning:
    avy--generic-jump called with 5 arguments, but accepts only 2-4
~/.emacs.d/elpa/avy-migemo-20180716.1455/avy-migemo-e.g.zzz-to-char.el:Warning:
    ‘avy--generic-jump’ is an obsolete function (as of 0.4.0); use
    ‘avy-jump’ instead.
```

呼び出す関数を`avy--generic-jump`から`avy-jump`に変更することで警告が出ないようにしました．
